### PR TITLE
updated gitignore to stop adding log files and folder to commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,9 @@ arc.dir
 *.pyt.xml
 *.zip
 
+log/
+*.log
+
 # Python
 *.py[cod]
 # Packages


### PR DESCRIPTION
@csmoore any interest in checking that this one works?
1) Check that there isn't a *./utils/test/log* folder in the repo
2) Run the tests:
     * cd ./utils/test
     * ./TestKickStart.bat
3) Afterwards, check that log folder and log files were created in *./utils/test/log*
4) Check they DON'T show up in the change list in GitHub for Windows.