### PR TITLE
Fix for #185

### DIFF
--- a/toolboxes/scripts/VisibilityUtilities.py
+++ b/toolboxes/scripts/VisibilityUtilities.py
@@ -504,7 +504,7 @@ def makeProfileGraph(inputFeatures):
         arcpy.AddMessage("Found {0} unique sight line IDs ...".format(len(sightLineIDs)))
         
         arcpy.AddField_management(inputFeatures,profileGraphName,"TEXT")
-        expression = '"profile" + str(!SourceOID!)'
+        expression = '"profile" + str(!SourceOID!) + ".png"'
         arcpy.CalculateField_management(inputFeatures,profileGraphName,expression, "PYTHON")
         
         # get visible and non-visible lines for each LLOS
@@ -572,9 +572,10 @@ def makeProfileGraph(inputFeatures):
         #for llosID in rawLOS.keys(): #UPDATE
         for llosID in list(rawLOS.keys()):
                 
-                graphInputList = rawLOS[llosID] # get the values for the current llos
-        # Current: {<SourceOID> : [<TarIsVis>, [<observerD=0.0>,<observerZ>],
-        #                                      [<segmentList0>,...,<segmentListN>]]}
+                graphInputList = rawLOS[llosID]
+                # get the values for the current llos
+                # Current: {<SourceOID> : [<TarIsVis>, [<observerD=0.0>,<observerZ>],
+                #                                      [<segmentList0>,...,<segmentListN>]]}
                 
                 targetVisibility = graphInputList[0]
                 observer = graphInputList[1]


### PR DESCRIPTION
needed to make the profile graph name match exactly what is in the key
field in the output LOS features.

## Description
simply adding the file extension to the profile graph match name seems to have worked.

## Related Issue
Fixes issue #185 

## Motivation and Context
Fixes issue #185 

## How Has This Been Tested?
Manually tested fix and verified test locally. Needs to be reviewed by @dfoll 

## Screenshots (if appropriate):

## Types of changes
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
