### PR TITLE
Address Issue #207

### DIFF
--- a/toolboxes/scripts/VisibilityUtilities.py
+++ b/toolboxes/scripts/VisibilityUtilities.py
@@ -1541,12 +1541,19 @@ def radialLineOfSight(inputObserverFeatures,
                                  srLocalWAZED,
                                  "PRESERVE_SHAPE")
         deleteme.append(bufferSurfaceSR)
+        
+        arcpy.AddMessage("Clipping image to observer buffers...")
+        
+        surfaceExtract = os.path.join(scratch, "surfaceExtract")
+
+        arcpy.env.mask = bufferSurfaceSR       
+        arcpy.gp.ExtractByMask_sa(inputSurface, bufferSurfaceSR, surfaceExtract)
+        deleteme.append(surfaceExtract)
 
         arcpy.AddMessage("Building viewshed of observers to surface...")
         tempViewshed = os.path.join(scratch, "tempViewshed")
         tempAGL = os.path.join(scratch, "tempAGL")
-        arcpy.env.mask = bufferSurfaceSR
-        saViewshed = sa.Viewshed(inputSurface,
+        saViewshed = sa.Viewshed(surfaceExtract,
                                  observersSurfaceSR,
                                  1.0,
                                  "CURVED_EARTH",


### PR DESCRIPTION
Use ExtractByMask on the elevation source with the extent of the observer buffers to reduce the amount of time the viewshed takes.

I have tested with 4 observers with a range of a 1000m in Desktop and Pro against the image service found here:

http://navigator.state.or.us/arcgis/services/Framework/Elevation_DEM_10m/ImageServer

It took about 50 secs in both applications

