### PR TITLE
Address issue #201

### DIFF
--- a/toolboxes/scripts/VisibilityUtilities.py
+++ b/toolboxes/scripts/VisibilityUtilities.py
@@ -79,9 +79,9 @@ def _getFieldNameList(targetTable, excludeList):
         for field in fields:
             if not excludeList or not excludeList == []:
                 if not field.name in excludeList:
-                    nameList.append(field.name)
+                    nameList.append(field.name.upper())
             else:
-                nameList.append(field.name)
+                nameList.append(field.name.upper())
         return nameList
     except arcpy.ExecuteError:
         # Get the tool error messages
@@ -1144,8 +1144,7 @@ def linearLineOfSight(inputObserverFeatures,
                       outputObservers,
                       outputTargets,
                       inputObstructionFeatures):
-    '''
-    
+    '''    
     '''
     global scratch
     addProfileGraphToSurfaceLine = True
@@ -1424,6 +1423,7 @@ def radialLineOfSight(inputObserverFeatures,
     inputSpatial Reference - spatial reference of outputVisibility features
     '''
     global scratch
+    
     try:
         #Need Spatial Analyst to run this tool
         if arcpy.CheckExtension("Spatial") == "Available":


### PR DESCRIPTION
The observer and target location feature classes created using the AddIn both contain a field called 'offset'.

When the Linear Line of Sight tool is run it checks if the field 'OFFSET' is present, if not it adds the field to the feature class. When python checks if the field exists in the dataset it is checking for a field name called 'OFFSET' (uppercase) not 'offset' (offset lowercase), which returns false, it then tries to add the OFFSET field to the dataset which causes the error as offset exists (the database is not case sensitive, unlike python). 

Easy solution was to use the .upper() function on the field names returned from the feature class, which prevents the field from being added when it is already present
