### PR TITLE
changed the input parameter order

### DIFF
--- a/toolboxes/scripts/GRGUtilities.py
+++ b/toolboxes/scripts/GRGUtilities.py
@@ -569,8 +569,8 @@ def GRGFromArea(AOI,
 
 
 def GRGFromPoint(starting_point,
+				 vertical_cells,
                  horizontal_cells,
-                 vertical_cells,
                  cell_width,
                  cell_height,
                  cell_units,


### PR DESCRIPTION
Changed the input parameter order to address issue number: Horizontal/Vertical inputs are reversed in Create GRG from Point #670

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The parameters being passed to the tool were not in the correct order
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->
Horizontal/Vertical inputs are reversed in Create GRG from Point #670
https://github.com/Esri/solutions-geoprocessing-toolbox/issues/670
## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The tool was not operating correctly
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
manually
## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
