### PR TITLE
Fix broken unit test on 10.3.1

### DIFF
--- a/utils/test/grg_tests/GRGCreateReferenceSystemGRGFromAreaTestCase.py
+++ b/utils/test/grg_tests/GRGCreateReferenceSystemGRGFromAreaTestCase.py
@@ -77,8 +77,7 @@ class GRGCreateReferenceSystemGRGFromAreaTestCase(unittest.TestCase, arcpyAssert
                                "IGNORE_EXTENSION_PROPERTIES",
                                "IGNORE_SUBTYPES",
                                "IGNORE_RELATIONSHIPCLASSES",
-                               "IGNORE_REPRESENTATIONCLASSES",
-                               "IGNORE_FIELDALIAS"]
+                               "IGNORE_REPRESENTATIONCLASSES"]
 
         UnitTestUtilities.checkGeoObjects([self.inputArea, self.inputArea10m])
 


### PR DESCRIPTION
Remove: Ignore_Field_Alias option that was apparently added after 10.3 to maintain 10.3 compatibility

See:  https://github.com/Esri/military-tools-geoprocessing-toolbox/issues/276#issuecomment-388216354 and https://github.com/Esri/military-tools-geoprocessing-toolbox/issues/276#issuecomment-388223649