### PR TITLE
Added GRG test for area

### DIFF
--- a/utils/test/grg_tests/GRGCreateGRGFromAreaTestCase.py
+++ b/utils/test/grg_tests/GRGCreateGRGFromAreaTestCase.py
@@ -124,7 +124,7 @@ class GRGCreateGRGFromAreaTestCase(unittest.TestCase):
         ==================================================================
         ''')
 
-        #Configuration.Logger.debug ("Check the size of the grids that have been created")
+
         primter_area = (cellWidth * 2) +  (cellHeight * 2)
         field_name = "Shape_Length"
         with arcpy.da.SearchCursor(output, field_name) as cursor:

--- a/utils/test/grg_tests/GRGCreateGRGFromAreaTestCase.py
+++ b/utils/test/grg_tests/GRGCreateGRGFromAreaTestCase.py
@@ -35,15 +35,15 @@ class GRGCreateGRGFromAreaTestCase(unittest.TestCase):
         Configuration.GetLogger()
         Configuration.GetPlatform()
         ''' End standalone initialization '''
-            
-        Configuration.Logger.debug("     GRGCreateGRGFromAreaTestCase.setUpClass")    
+
+        Configuration.Logger.debug("     GRGCreateGRGFromAreaTestCase.setUpClass")
         UnitTestUtilities.checkArcPy()
 
         if not arcpy.Exists(Configuration.militaryScratchGDB):
             Configuration.militaryScratchGDB = UnitTestUtilities.createScratch(Configuration.currentPath)
 
         Configuration.Logger.debug("Import Toolbox: " + Configuration.toolboxUnderTest)
-        arcpy.ImportToolbox(Configuration.toolboxUnderTest)  
+        arcpy.ImportToolbox(Configuration.toolboxUnderTest)
         Configuration.Logger.debug("Done Toolbox Import")
 
         arcpy.env.overwriteOutput = True
@@ -99,9 +99,9 @@ class GRGCreateGRGFromAreaTestCase(unittest.TestCase):
         # 1: Check the expected return value
         self.assertIsNotNone(toolOutput, "No output returned from tool")
         outputOut = toolOutput.getOutput(0)
-        self.assertEqual(output, outputOut, "Unexpected return value from tool") 
+        self.assertEqual(output, outputOut, "Unexpected return value from tool")
 
-        # 2: Check the number of features created 
+        # 2: Check the number of features created
         Configuration.Logger.debug ('''
         =================================================================
         Test #2 Check to see if the amount of features created is the
@@ -127,10 +127,10 @@ class GRGCreateGRGFromAreaTestCase(unittest.TestCase):
         #Configuration.Logger.debug ("Check the size of the grids that have been created")
         primter_area = (cellWidth * 2) +  (cellHeight * 2)
         field_name = "Shape_Length"
-        cursor = arcpy.da.SearchCursor(output,field_name)
-        for row in cursor:
-            testlen= primter_area - int(row[0])
-            self.assertLessEqual(testlen, 1)
+        with arcpy.da.SearchCursor(output, field_name) as cursor:
+            for row in cursor:
+                testlen= primter_area - int(row[0])
+                self.assertLessEqual(testlen, 1)
 
 if __name__ == "__main__":
-    unittest.main()       
+    unittest.main()

--- a/utils/test/grg_tests/GRGCreateGRGFromAreaTestCase.py
+++ b/utils/test/grg_tests/GRGCreateGRGFromAreaTestCase.py
@@ -102,10 +102,35 @@ class GRGCreateGRGFromAreaTestCase(unittest.TestCase):
         self.assertEqual(output, outputOut, "Unexpected return value from tool") 
 
         # 2: Check the number of features created 
+        Configuration.Logger.debug ('''
+        =================================================================
+        Test #2 Check to see if the amount of features created is the
+        number expected.
+        We expect 40
+        ==================================================================
+        ''')
         result = arcpy.GetCount_management(output)
         count = int(result.getOutput(0))
         Configuration.Logger.debug("Output number features: " + str(count))
         self.assertEqual(count, 40)
+
+        # 3: Check the size of the grids that have been created
+        Configuration.Logger.debug ('''
+        ==================================================================
+        Test #3 Check the size of the grids that have been created using the
+        assertLessEqual. Comparing this to the cellwidth and height times 2.
+        If the number returned  is less than 1 the test passes.This is used
+        because of the percision of the field does not produce the exact number.
+        ==================================================================
+        ''')
+
+        #Configuration.Logger.debug ("Check the size of the grids that have been created")
+        primter_area = (cellWidth * 2) +  (cellHeight * 2)
+        field_name = "Shape_Length"
+        cursor = arcpy.da.SearchCursor(output,field_name)
+        for row in cursor:
+            testlen= primter_area - int(row[0])
+            self.assertLessEqual(testlen, 1)
 
 if __name__ == "__main__":
     unittest.main()       


### PR DESCRIPTION
Added a test to check the size of each polygon based on the perimeter. Using the length and height inputs  * 2 we understand the expected perimeter. The precision of the attribute does not give us an integer and because of that it can be off by one depending on rounding. Using less than or equal to one we can confirm that each grg polygon is the size we expect it to be.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
using the test that was created by @dfoll  I added a test to check the perimeter of each polygon. 
## Related Issue
<!--- This project only accepts pull requests related to open issues -->
Wanted to add grg tests, but did not see the issue related to adding tests

