### PR TITLE
Raster Compare test fix

### DIFF
--- a/utils/test/visibility_tests/VisibilityUtilitiesTestCase.py
+++ b/utils/test/visibility_tests/VisibilityUtilitiesTestCase.py
@@ -194,7 +194,7 @@ class VisibilityUtilitiesTestCase(unittest.TestCase, arcpyAssert.FeatureClassAss
         resultClippedRaster = os.path.join(Configuration.militaryScratchGDB, "resultClippedRaster")
         resultClippedRaster = VisibilityUtilities._clipRasterToArea(self.inputSurface, self.inputArea, resultClippedRaster)
         deleteIntermediateData.append(resultClippedRaster)
-        result = arcpy.RasterCompare_management(expectedOutput, resultClippedRaster, "RASTER_DATASET").getOutput(1)
+        result = arcpy.RasterCompare_management(expectedOutput, resultClippedRaster,"RASTER_DATASET","Columns And Rows;NoData;Pixel Value;Raster Attribute Table","","","All 1 Fraction","","").getOutput(1)
         self.assertEqual(result, "true", "Raster Compare failed: \n %s" % arcpy.GetMessages())
 
     def test_getUniqueValuesFromField001(self):


### PR DESCRIPTION
Adding tolerances and ommiting certain fields to allow proper comparison of raster results.

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
See: #275 - https://github.com/Esri/military-tools-geoprocessing-toolbox/issues/275#issuecomment-388518803

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
