### PR TITLE
Removed test that is breaking harness

### DIFF
--- a/utils/test/grg_tests/GRGCreateGRGFromPointTestCase.py
+++ b/utils/test/grg_tests/GRGCreateGRGFromPointTestCase.py
@@ -111,7 +111,8 @@ class GRGCreateGRGFromPointTestCase(unittest.TestCase):
         expectedCount = rows * cols
         self.assertEqual(count, expectedCount, "Unexpected number of output feature created")
 
-    def testGRGPointTarget_Rotated(self):
+    # Test Removed because it broke test harness
+    def _testGRGPointTarget_Rotated(self):
         Configuration.Logger.debug(".....GRGCreateGRGFromPointTestCase.testGRGPointTarget_Rotated")
 
         #inputs


### PR DESCRIPTION
Test/tool call was locking GDB and preventing clean deletion - need to look further into cause - removing test for now while it is investigated
