### PR TITLE
Adding logic to fix the issue on crash produced by LLOS

### DIFF
--- a/toolboxes/scripts/VisibilityUtilities.py
+++ b/toolboxes/scripts/VisibilityUtilities.py
@@ -626,6 +626,7 @@ def makeProfileGraph(inputFeatures):
                 #if debug == True: arcpy.AddMessage("graphPath: " + str(graphPath))
                 pylab.savefig(graphPath, dpi=900)
                 pylab.cla() # clear the graph???
+                pylab.close()  #closing pylab to prevent crashes
                 
                 graphLocationDict[llosID] = graphPath
                 deleteme.append(graphPath)


### PR DESCRIPTION
Adding pylab.close()  to the script to prevent crashing on the closing of ArcMap and ArcScene. This has been tested both on ArcMap and ArcScene. Please do the same upon merging the pull request.


Issue addresses ArcMap and ArcScene crashing on all versions. 