### PR TITLE
Update field type to TEXT to fix Table to Ellipse tool fail

### DIFF
--- a/toolboxes/scripts/ConversionUtilities.py
+++ b/toolboxes/scripts/ConversionUtilities.py
@@ -179,8 +179,8 @@ def addUniqueRowID(dataset, fieldName="JoinID"):
     try:
         counter = 1
         # add unique ID field
-        if debug: arcpy.AddMessage("Adding LONG field " + str(fieldName))
-        arcpy.AddField_management(dataset, fieldName, "LONG")
+        if debug: arcpy.AddMessage("Adding Text field " + str(fieldName))
+        arcpy.AddField_management(dataset, fieldName, "TEXT")
     
         # add unique numbers to each row
         fields = [str(fieldName)]

--- a/utils/test/TestRunner.py
+++ b/utils/test/TestRunner.py
@@ -172,13 +172,13 @@ def addMilitarySuite():
     testSuite.addTests(ConversionTestSuite.getTestSuite())
     
     from distance_tests import RangeRingTestSuite
-    testSuite.addTests(RangeRingTestSuite.getTestSuite())
+    #testSuite.addTests(RangeRingTestSuite.getTestSuite())
     
     from grg_tests import GRGTestSuite
-    testSuite.addTests(GRGTestSuite.getTestSuite())
+    #testSuite.addTests(GRGTestSuite.getTestSuite())
 
     from visibility_tests import VisibilityTestSuite
-    testSuite.addTests(VisibilityTestSuite.getTestSuite())
+    #testSuite.addTests(VisibilityTestSuite.getTestSuite())
     
     return testSuite
 

--- a/utils/test/TestRunner.py
+++ b/utils/test/TestRunner.py
@@ -172,13 +172,13 @@ def addMilitarySuite():
     testSuite.addTests(ConversionTestSuite.getTestSuite())
     
     from distance_tests import RangeRingTestSuite
-    #testSuite.addTests(RangeRingTestSuite.getTestSuite())
+    testSuite.addTests(RangeRingTestSuite.getTestSuite())
     
     from grg_tests import GRGTestSuite
-    #testSuite.addTests(GRGTestSuite.getTestSuite())
+    testSuite.addTests(GRGTestSuite.getTestSuite())
 
     from visibility_tests import VisibilityTestSuite
-    #testSuite.addTests(VisibilityTestSuite.getTestSuite())
+    testSuite.addTests(VisibilityTestSuite.getTestSuite())
     
     return testSuite
 


### PR DESCRIPTION
Update field type to TEXT to fix Table to Ellipse tool fail - was previously a Long.