### PR TITLE
#274- Fix Conversion test errors

### DIFF
--- a/toolboxes/scripts/ConversionUtilities.py
+++ b/toolboxes/scripts/ConversionUtilities.py
@@ -178,14 +178,17 @@ def addUniqueRowID(dataset, fieldName="JoinID"):
     '''
     try:
         counter = 1
-        # add unique ID field
-        if debug: arcpy.AddMessage("Adding Text field " + str(fieldName))
-        arcpy.AddField_management(dataset, fieldName, "TEXT")
+
+        # add unique ID field if it does not already exist
+        desc = arcpy.Describe(dataset)
+        if not fieldName in [field.name for field in desc.Fields] :
+            if debug: arcpy.AddMessage("Adding Text field: " + str(fieldName))
+            arcpy.AddField_management(dataset, fieldName, "TEXT")
     
         # add unique numbers to each row
-        fields = [str(fieldName)]
+        updatedFields = [str(fieldName)]
         arcpy.AddMessage("Adding unique row IDs...")
-        rows = arcpy.da.UpdateCursor(dataset,fields)
+        rows = arcpy.da.UpdateCursor(dataset, updatedFields)
         for row in rows:
             row[0] = counter
             rows.updateRow(row)
@@ -193,8 +196,7 @@ def addUniqueRowID(dataset, fieldName="JoinID"):
         del rows
         
         # set output
-        return dataset
-        
+        return dataset        
     
     except arcpy.ExecuteError:
         error = True

--- a/utils/test/visibility_tests/HighestPointsTestCase.py
+++ b/utils/test/visibility_tests/HighestPointsTestCase.py
@@ -104,7 +104,7 @@ class HighestPointsTestCase(unittest.TestCase):
             # 1: Check the expected return value
             self.assertIsNotNone(toolOutput, "No output returned from tool")
             outputOut = toolOutput.getOutput(0)
-            self.assertEqual(self.outputLOS, outputOut, "Unexpected return value from tool") 
+            self.assertEqual(self.outputPoints, outputOut, "Unexpected return value from tool") 
 
         self.assertTrue(arcpy.Exists(self.outputPoints), "Output dataset does not exist or was not created")
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

Fix errors introduced in conversion tests by changes in #319 - https://github.com/Esri/military-tools-geoprocessing-toolbox/issues/274#issuecomment-395798154

## Description
<!--- Describe your changes in detail -->

Fix errors introduced in conversion tests by changes in #319 - https://github.com/Esri/military-tools-geoprocessing-toolbox/issues/274#issuecomment-395798154 - some test data (Tableto2PointLine-single.csv) already had a text field called JoinID which was causing addfield step to fail. 

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
