### PR TITLE
Issue #320 - add tests for no area supplied

### DIFF
--- a/utils/test/ArcGISProTestKickStart.bat
+++ b/utils/test/ArcGISProTestKickStart.bat
@@ -40,6 +40,13 @@ REM name is optional; if not specified, name will be specified for you
 set LOG=
 REM === LOG SETUP ====================================
 
+REM === Remove previous scratch workspaces
+del /s /q /f scratch.gdb 1>nul
+rmdir /s /q scratch.gdb 
+del /s /q /f %temp%\scratch.gdb 1>nul 
+rmdir /s /q %temp%\scratch.gdb
+REM === Remove previous scratch workspaces
+
 ECHO Testing with ArcGIS Pro ===============================
 REM The location of python.exe will depend upon your installation
 REM of ArcGIS Pro. Modify the following line as necessary:

--- a/utils/test/ArcMapTestKickStart.bat
+++ b/utils/test/ArcMapTestKickStart.bat
@@ -41,9 +41,18 @@ REM name is optional; if not specified, name will be specified for you
 set LOG=
 REM === LOG SETUP ====================================
 
-REM You may need to add this section in if ArcMap Python is not in your PATH
+REM === SET ARCPY PATH IF NECESSARY
+REM You may need to add/uncomment this section in if ArcMap Python is not already in your PATH
 REM SET ARCMAP_PYTHON_PATH=C:\Python27\ArcGIS10.4
 REM SET PATH=%ARCMAP_PYTHON_PATH%;%PATH%
+REM === SET ARCPY PATH IF NECESSARY
+
+REM === Remove previous scratch workspaces
+del /s /q /f scratch.gdb 1>nul
+rmdir /s /q scratch.gdb 
+del /s /q /f %temp%\scratch.gdb 1>nul 
+rmdir /s /q %temp%\scratch.gdb
+REM === Remove previous scratch workspaces
 
 ECHO Testing with ArcMap ===============================
 

--- a/utils/test/visibility_tests/HighestPointsTestCase.py
+++ b/utils/test/visibility_tests/HighestPointsTestCase.py
@@ -97,9 +97,10 @@ class HighestPointsTestCase(unittest.TestCase):
             # WORKAROUND: To arpy exception with Pro: 
             # "DeprecationWarning: Product and extension licensing is no longer handled with this method."
             # when this tool is run in Pro from unit test driver
-            pass
+            if (Configuration.Platform == Configuration.PLATFORM_PRO):
+                pass
 
-        # WORKAROUND: see about - toolOutput not being set because of exception on return
+        # WORKAROUND: see above - toolOutput not being set because of exception on return
         if (Configuration.Platform != Configuration.PLATFORM_PRO):        
             # 1: Check the expected return value
             self.assertIsNotNone(toolOutput, "No output returned from tool")
@@ -117,6 +118,27 @@ class HighestPointsTestCase(unittest.TestCase):
             elevation = row.Elevation
             self.assertEqual(elevation, int(1123), "Bad elevation value: %s" % str(elevation))
             row = rows.next()
+        return
+
+    def test_highest_points_no_input_area(self):
+        ''' Test Find Local Peaks for ArcGIS Desktop '''
+        Configuration.Logger.info(".....HighestPointsTestCase.test_highest_points_no_input_area")
+
+        arcpy.env.overwriteOutput = True
+
+        errorMsgs = None
+        noInputArea = None # <-- Bad Input Area
+
+        try : 
+           arcpy.HighestPoints_mt(noInputArea, self.inputSurface, self.outputPoints)
+        except arcpy.ExecuteError:
+            # ExecuteError is expected because of bad input
+            errorMsgs = arcpy.GetMessages(severity = 2)
+
+        self.assertIsNotNone(errorMsgs, "Error Message Expected for No Input Area")
+        # 2 Error Messages: "No Input Area" "Tool Failed" - errorMsgs is a string not list
+        self.assertEqual(errorMsgs.count('\n'), 2, "Only 2 Error Messages Expected for No Input Area")
+
         return
 
 if __name__ == "__main__":

--- a/utils/test/visibility_tests/LinearLineOfSightTestCase.py
+++ b/utils/test/visibility_tests/LinearLineOfSightTestCase.py
@@ -121,9 +121,10 @@ class LinearLineOfSightTestCase(unittest.TestCase):
             # WORKAROUND: To arpy exception with Pro: 
             # "DeprecationWarning: Product and extension licensing is no longer handled with this method."
             # when this tool is run in Pro from unit test driver
-            pass
+            if (Configuration.Platform == Configuration.PLATFORM_PRO):
+                pass
 
-        # WORKAROUND: see about - toolOutput not being set because of exception on return
+        # WORKAROUND: see above - toolOutput not being set because of exception on return
         if (Configuration.Platform != Configuration.PLATFORM_PRO):        
             # 1: Check the expected return value
             self.assertIsNotNone(toolOutput, "No output returned from tool")


### PR DESCRIPTION
Changes:

1. Add an auto/unit-test for #320
2. Add fix  failing when run standalone in Pro 2.1 (workaround for execute error if gp.checkout license called)
3. Add workaround to runner .bat for corrupted scratch gdbs
