### PR TITLE
Implement workaround(s) for GetCount failure in Find Local Peaks

### DIFF
--- a/toolboxes/scripts/VisibilityUtilities.py
+++ b/toolboxes/scripts/VisibilityUtilities.py
@@ -989,8 +989,7 @@ def findLocalPeaks(inputAreaFeature,
         if arcpy.env.scratchWorkspace:
             scratch = arcpy.env.scratchWorkspace
         else:
-            scratch = r"%scratchGDB%"
-            
+            scratch = r"%scratchGDB%"            
         
         #Get SR of the surface and set as default output
         surfaceDescribe = arcpy.Describe(inputSurfaceRaster)
@@ -1020,10 +1019,13 @@ def findLocalPeaks(inputAreaFeature,
         arcpy.AddMessage("Finding inverted sinks...")
         saFlowDirection = sa.FlowDirection(invertedMapAlgebra, "NORMAL")
         saSink = sa.Sink(saFlowDirection)
-        invertedSinks = os.path.join(scratch, "invertedSinks")
+        invertedSinks = os.path.join("in_memory", "invertedSinks")
         saSink.save(invertedSinks)
         deleteme.append(invertedSinks)
-                
+             
+        #need to make sure there is a VAT for GetCount
+        arcpy.BuildRasterAttributeTable_management(invertedSinks, "Overwrite")
+                   
         #check the number of sink values before proceeding as no sinks will cause an error
         result = arcpy.GetCount_management(invertedSinks)
         numberSinkValues = int(result.getOutput(0))


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

See: #345 

On recent versions of ArcGIS (Pro 2.1, ArcMap 10.6) calling GetCount_management on the raster surface produced by Find Local Peaks tool was failing and causing tool to fail.

## Description
<!--- Describe your changes in detail -->

Added workaround recommended in #345 [workaround](https://github.com/Esri/military-tools-geoprocessing-toolbox/issues/345#issuecomment-399604207)  

## Related Issue

See: #345 

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
See: #345 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Manual

## Screenshots (if appropriate):

![image](https://user-images.githubusercontent.com/3090809/41870131-24c8dbd2-7889-11e8-991e-0e77c3b914ce.png)

![image](https://user-images.githubusercontent.com/3090809/41870161-41224d72-7889-11e8-8aac-c7fa0cb08fda.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.

