### PR TITLE
Add "gridded-reference-graphic" tag so this repo shows up in search

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,5 +119,5 @@ limitations under the License.
 A copy of the license is available in the repository's
 [license.txt](license.txt) file.
 
-[](Esri Tags: ArcGISSolutions Military Defense Military-Tools-for-ArcGIS)
+[](Esri Tags: ArcGISSolutions Military Defense Military-Tools-for-ArcGIS gridded-reference-graphic)
 [](Esri Language: Python)


### PR DESCRIPTION
The GRG Home page GitHub button is showing search results that do not include this repo. Adding the tag "gridded-reference-graphic" so it will also show up in the results.
