### PR TITLE
Addresses #388

### DIFF
--- a/tools/militarytools/esri/toolboxes/scripts/ConversionUtilities.py
+++ b/tools/militarytools/esri/toolboxes/scripts/ConversionUtilities.py
@@ -530,7 +530,8 @@ def tableToEllipse(inputTable,
 
         deleteme = []
         scratch = '%scratchGDB%'
-        joinFieldName = "JoinID"
+        joinFieldName = 'JoinID'
+        deleteJoinFieldName = 'JoinID_1'
         
         if env.scratchWorkspace:
             scratch = env.scratchWorkspace
@@ -574,11 +575,10 @@ def tableToEllipse(inputTable,
         #Join original table fields to output
         arcpy.AddMessage("Joining fields from input table to output line features...")
         arcpy.JoinField_management(outputEllipseFeatures, joinFieldName,
-                                   copyRows, joinFieldName,
-                                   originalTableFieldNames)
+                                   copyRows, joinFieldName) 
         
         arcpy.DeleteField_management(outputEllipseFeatures,
-                                     [joinFieldName])
+                                     [joinFieldName, deleteJoinFieldName])
 
         return outputEllipseFeatures
     


### PR DESCRIPTION
This fix addresses #388. `originTableFieldNames` in [line 578](https://github.com/Esri/military-tools-geoprocessing-toolbox/blob/dev/tools/militarytools/esri/toolboxes/scripts/ConversionUtilities.py#L578) was the issue.