### PR TITLE
Allow radials to be set to zero from RangeRing tools

### DIFF
--- a/tools/militarytools/esri/toolboxes/scripts/RangeRingUtils.py
+++ b/tools/militarytools/esri/toolboxes/scripts/RangeRingUtils.py
@@ -107,8 +107,8 @@ def rangeRingsFromList(centerFC, rangeList, distanceUnits, numRadials, outputRin
 
 def rangeRingsFromMinMax(centerFC, rangeMin, rangeMax, distanceUnits, numRadials, outputRingFeatures, outputRadialFeatures, sr):
     ''' Make range ring features from only two distances, a minimum and a maximum '''
-    if distBetween <= 0.0:
-        arcpy.AddError("Distance between rings must be > 0")
+    if (rangeMin < 0.0) or (rangeMax <= 0.0) or (rangeMin > rangeMax):
+        arcpy.AddError("Range parameters are not valid")
         return [None, None]
 
     rangeList = [min(rangeMin, rangeMax), max(rangeMin, rangeMax)]

--- a/tools/militarytools/esri/toolboxes/scripts/RangeRingUtils.py
+++ b/tools/militarytools/esri/toolboxes/scripts/RangeRingUtils.py
@@ -43,7 +43,11 @@ def rangeRingsFromList(centerFC, rangeList, distanceUnits, numRadials, outputRin
     ''' Make range ring features from a center, and list of distances '''
     try:
 
-        #if sr == "#" or sr == "" or sr == None:
+        if (centerFC is None) or (rangeList is None) or (len(rangeList) == 0) \
+            or (outputRingFeatures == None) :
+            arcpy.AddError("Bad parameters supplied to rangeRingsFromList")
+            return [None, None]
+
         if not sr:
             msg = r"Using default spatial reference: " + str(srDefault.name)
             arcpy.AddWarning(msg)
@@ -54,6 +58,11 @@ def rangeRingsFromList(centerFC, rangeList, distanceUnits, numRadials, outputRin
 
         # Create Rings...
         numCenterPoints = arcpy.GetCount_management(centerFC).getOutput(0)
+
+        if int(numCenterPoints) < 1:
+            arcpy.AddError("At least one input center point is required")
+            return [None, None]
+
         numRingsPerCenter = len(rangeList)
         totalNumRings = int(numCenterPoints) * int(numRingsPerCenter)
         totalNumRadials = int(numCenterPoints) * int(numRadials)
@@ -63,10 +72,16 @@ def rangeRingsFromList(centerFC, rangeList, distanceUnits, numRadials, outputRin
 
         # Create Radials...
         arcpy.AddMessage("Making radials " + str(totalNumRadials) + " (" + str(numRadials) + " for " + str(numCenterPoints) + " centers)...")
-        rm.makeRadials(numRadials)
-        outRadials = rm.saveRadialsAsFeatures(outputRadialFeatures)
+        if (outputRadialFeatures is not None) and (numRadials > 0):
+            rm.makeRadials(numRadials)
+            outRadials = rm.saveRadialsAsFeatures(outputRadialFeatures)
+        else:
+            outRadials = None
+            if (numRadials < 0):
+                arcpy.AddWarning("Number of radials must be positive")
 
         return [outRings, outRadials]
+
     except arcpy.ExecuteError:
         # Get the tool error messages
         msgs = arcpy.GetMessages()
@@ -92,14 +107,22 @@ def rangeRingsFromList(centerFC, rangeList, distanceUnits, numRadials, outputRin
 
 def rangeRingsFromMinMax(centerFC, rangeMin, rangeMax, distanceUnits, numRadials, outputRingFeatures, outputRadialFeatures, sr):
     ''' Make range ring features from only two distances, a minimum and a maximum '''
+    if distBetween <= 0.0:
+        arcpy.AddError("Distance between rings must be > 0")
+        return [None, None]
+
     rangeList = [min(rangeMin, rangeMax), max(rangeMin, rangeMax)]
     return rangeRingsFromList(centerFC, rangeList, distanceUnits, numRadials, outputRingFeatures, outputRadialFeatures, sr)
 
 def rangeRingsFromInterval(centerFC, numRings, distBetween, distanceUnits, numRadials, outputRingFeatures, outputRadialFeatures, sr):
+
     ''' Classic range rings from number of rings, and distance between rings  '''
+    if distBetween <= 0.0:
+        arcpy.AddError("Distance between rings must be > 0")
+        return [None, None]
+
     rangeList = [x * distBetween for x in range(1, numRings + 1)]
     return rangeRingsFromList(centerFC, rangeList, distanceUnits, numRadials, outputRingFeatures, outputRadialFeatures, sr)
-
 
 
 class RingMaker:

--- a/tools/militarytools/esri/toolboxes/scripts/RangeRingsFromInterval.py
+++ b/tools/militarytools/esri/toolboxes/scripts/RangeRingsFromInterval.py
@@ -58,6 +58,13 @@ optionalSpatialReferenceAsText = arcpy.GetParameterAsText(7)
 if optionalSpatialReferenceAsText == "#" or optionalSpatialReferenceAsText == "":
     optionalSpatialReference = None
 
+# Allow radials to be optional
+if inputNumberOfRadials == "#" or inputNumberOfRadials == "" :
+    inputNumberOfRadials = 0
+
+if outputRadialFeatures == "#" or outputRadialFeatures == "" :
+    outputRadialFeatures = None
+
 def main():
     try:
         # get/set environment

--- a/utils/test/distance_tests/RangeRingUtilsTestCase.py
+++ b/utils/test/distance_tests/RangeRingUtilsTestCase.py
@@ -257,6 +257,102 @@ class RangeRingUtilsTestCase(unittest.TestCase):
         deleteIntermediateData.append(radials)
         return
 
+    def test_rangeRingsFromMinMaxEdgeCases(self):
+        runToolMessage = ".....RangeRingsUtilsTestCase.test_rangeRingsFromMinMaxEdgeCases"
+        Configuration.Logger.info(runToolMessage)
+        
+        ##########################
+        # numRadials = 0 Edge Case
+        ##########################
+
+        numCenters = int(arcpy.GetCount_management(self.pointGeographic).getOutput(0))
+        numRadials = 0
+        minRange = 100.0
+        maxRange = 1000.0
+        rings = os.path.join(Configuration.militaryScratchGDB, "newRings")
+        radials = os.path.join(Configuration.militaryScratchGDB, "newRadials") 
+
+        if arcpy.Exists(rings):
+            arcpy.Delete_management(rings)
+        if arcpy.Exists(radials):
+            arcpy.Delete_management(radials)
+
+        rr = RangeRingUtils.rangeRingsFromMinMax(self.pointGeographic,
+                                                 minRange,
+                                                 maxRange,
+                                                 "METERS",
+                                                 numRadials,
+                                                 rings,
+                                                 radials,
+                                                 srWAZED)
+
+        outRings = rr[0]
+        outRadials = rr[1]
+
+        self.assertTrue(arcpy.Exists(outRings), "Ring features not created or do not exist")
+        self.assertEqual(int(arcpy.GetCount_management(outRings).getOutput(0)), numCenters * 2, "Wrong number of expected ring features")
+
+        self.assertIsNone(outRadials)
+    
+        ##########################
+        # maxRange = 0 Edge Case
+        ##########################
+
+        numRadials = 8
+        maxRange = 0.0
+
+        if arcpy.Exists(rings):
+            arcpy.Delete_management(rings)
+        if arcpy.Exists(radials):
+            arcpy.Delete_management(radials)
+
+        rr = RangeRingUtils.rangeRingsFromMinMax(self.pointGeographic,
+                                                 minRange,
+                                                 maxRange,
+                                                 "METERS",
+                                                 numRadials,
+                                                 rings,
+                                                 radials,
+                                                 srWAZED)
+
+        outRings = rr[0]
+        outRadials = rr[1]
+
+        self.assertIsNone(outRings)
+        self.assertIsNone(outRadials)
+
+        ##########################
+        # maxRange < minRange Edge Case
+        ##########################
+
+        numRadials = 8
+        minRange = 1000.0
+        maxRange = 100.0
+
+        if arcpy.Exists(rings):
+            arcpy.Delete_management(rings)
+        if arcpy.Exists(radials):
+            arcpy.Delete_management(radials)
+
+        rr = RangeRingUtils.rangeRingsFromMinMax(self.pointGeographic,
+                                                 minRange,
+                                                 maxRange,
+                                                 "METERS",
+                                                 numRadials,
+                                                 rings,
+                                                 radials,
+                                                 srWAZED)
+
+        outRings = rr[0]
+        outRadials = rr[1]
+
+        self.assertIsNone(outRings)
+        self.assertIsNone(outRadials)
+
+        deleteIntermediateData.append(rings)
+
+        return
+
     def test_rangeRingsFromList(self):
         ''' testing rangeRingsFromList method'''
         runToolMessage = ".....RangeRingsUtilsTestCase.test_rangeRingsFromList"

--- a/utils/test/distance_tests/RangeRingUtilsTestCase.py
+++ b/utils/test/distance_tests/RangeRingUtilsTestCase.py
@@ -295,6 +295,104 @@ class RangeRingUtilsTestCase(unittest.TestCase):
 
         deleteIntermediateData.append(rings)
         deleteIntermediateData.append(radials)
+
+        return
+
+    def test_rangeRingsFromIntervalEdgeCases(self):
+        ''' testing rangeRingsFromInterval method'''
+        runToolMessage = ".....RangeRingsUtilsTestCase.test_rangeRingsFromIntervalEdgeCases"
+        Configuration.Logger.info(runToolMessage)
+
+        ##########################
+        # numRadials = 0 Edge Case
+        ##########################
+             
+        numCenters = int(arcpy.GetCount_management(self.pointGeographic).getOutput(0))
+        numRadials = 0
+        rings = os.path.join(Configuration.militaryScratchGDB, "newRings")
+        radials = os.path.join(Configuration.militaryScratchGDB, "newRadials")
+
+        if arcpy.Exists(rings):
+            arcpy.Delete_management(rings)
+        if arcpy.Exists(radials):
+            arcpy.Delete_management(radials)
+
+        numRings = 4
+        distanceBetween = 200.0
+        rr = RangeRingUtils.rangeRingsFromInterval(self.pointGeographic,
+                                                   numRings,
+                                                   distanceBetween,
+                                                   "METERS",
+                                                   numRadials,
+                                                   rings,
+                                                   radials,
+                                                   srWAZED)
+        outRings = rr[0]
+        outRadials = rr[1]
+
+        self.assertTrue(arcpy.Exists(outRings), "Ring features not created or do not exist")
+        self.assertEqual(int(arcpy.GetCount_management(outRings).getOutput(0)), 4 * numCenters, "Wrong number of expected ring features")
+
+        self.assertIsNone(outRadials)
+
+        ##########################
+        # numRings = 0 Edge Case
+        ##########################
+
+        numRadials = 4
+
+        if arcpy.Exists(rings):
+            arcpy.Delete_management(rings)
+        if arcpy.Exists(radials):
+            arcpy.Delete_management(radials)
+
+        numRings = 0
+
+        rr = RangeRingUtils.rangeRingsFromInterval(self.pointGeographic,
+                                                    numRings,
+                                                    distanceBetween,
+                                                    "METERS",
+                                                    numRadials,
+                                                    rings,
+                                                    radials,
+                                                    srWAZED)
+
+        outRings = rr[0]
+        outRadials = rr[1]
+
+        self.assertIsNone(outRings)
+        self.assertIsNone(outRadials)
+
+        ##########################
+        # distanceBetween = 0 Edge Case
+        ##########################
+
+        if arcpy.Exists(rings):
+            arcpy.Delete_management(rings)
+        if arcpy.Exists(radials):
+            arcpy.Delete_management(radials)
+
+        numRings = 4
+        numRadials = 4
+        distanceBetween = 0
+
+        rr = RangeRingUtils.rangeRingsFromInterval(self.pointGeographic,
+                                                    numRings,
+                                                    distanceBetween,
+                                                    "METERS",
+                                                    numRadials,
+                                                    rings,
+                                                    radials,
+                                                    srWAZED)
+
+        outRings = rr[0]
+        outRadials = rr[1]
+
+        self.assertIsNone(outRings)
+        self.assertIsNone(outRadials)
+
+        deleteIntermediateData.append(rings)
+
         return
 
     def test_rangeRingsFromInterval(self):
@@ -306,6 +404,12 @@ class RangeRingUtilsTestCase(unittest.TestCase):
         numRadials = 8
         rings = os.path.join(Configuration.militaryScratchGDB, "newRings")
         radials = os.path.join(Configuration.militaryScratchGDB, "newRadials")
+
+        if arcpy.Exists(rings):
+            arcpy.Delete_management(rings)
+        if arcpy.Exists(radials):
+            arcpy.Delete_management(radials)
+
         numRings = 4
         distanceBetween = 200.0
         rr = RangeRingUtils.rangeRingsFromInterval(self.pointGeographic,


### PR DESCRIPTION
See Issue #384 

Changes:

1. #384 - allow radials = 0
2. Add better error checking for values
3. Add test cases for error checking

Show behave like this now:

![image](https://user-images.githubusercontent.com/3090809/53500171-d88ab900-3a77-11e9-8808-6eedad61aba1.png)
